### PR TITLE
Modify Column Definition from String to Integer for Questions.category

### DIFF
--- a/projects/02_trivia_api/starter/backend/models.py
+++ b/projects/02_trivia_api/starter/backend/models.py
@@ -29,7 +29,7 @@ class Question(db.Model):
   id = Column(Integer, primary_key=True)
   question = Column(String)
   answer = Column(String)
-  category = Column(String)
+  category = Column(Integer)
   difficulty = Column(Integer)
 
   def __init__(self, question, answer, category, difficulty):
@@ -76,3 +76,4 @@ class Category(db.Model):
       'id': self.id,
       'type': self.type
     }
+


### PR DESCRIPTION
In the `models.py`, the datatype for the category column was changed from `String` to `Integer`

The `Question.category` is a foreign key reference to the `id` column of the table `Category`