### PR TITLE
fix: AttributeError in Fyyur starter code

### DIFF
--- a/projects/01_fyyur/starter_code/app.py
+++ b/projects/01_fyyur/starter_code/app.py
@@ -67,7 +67,7 @@ def format_datetime(value, format='medium'):
       format="EEEE MMMM, d, y 'at' h:mma"
   elif format == 'medium':
       format="EE MM, dd, y h:mma"
-  return babel.dates.format_datetime(date, format)
+  return babel.dates.format_datetime(date, format, locale='en')
 
 app.jinja_env.filters['datetime'] = format_datetime
 


### PR DESCRIPTION
If the locale argument is not specified when calling babel.dates.format_datetime(), it throws the following error:
AttributeError: 'NoneType' object has no attribute 'days'