### PR TITLE
Fix for broken form on 'create artist' page

### DIFF
--- a/projects/01_fyyur/starter_code/templates/forms/new_artist.html
+++ b/projects/01_fyyur/starter_code/templates/forms/new_artist.html
@@ -26,11 +26,11 @@
       <div class="form-group">
         <label for="genres">Genres</label>
         <small>Ctrl+Click to select multiple</small>
-        {{ form.genres(class_ = 'form-control', placeholder='Genres, separated by commas', id=form.state, autofocus = true) }}
+        {{ form.genres(class_ = 'form-control', placeholder='Genres, separated by commas', autofocus = true) }}
       </div>
       <div class="form-group">
-          <label for="genres">Facebook Link</label>
-          {{ form.facebook_link(class_ = 'form-control', placeholder='http://', id=form.state, autofocus = true) }}
+          <label for="facebook_link">Facebook Link</label>
+          {{ form.facebook_link(class_ = 'form-control', placeholder='http://', autofocus = true) }}
         </div>
       <input type="submit" value="Create Venue" class="btn btn-primary btn-lg btn-block">
     </form>


### PR DESCRIPTION
Removed 'id=form.state' attribute to fix broken display of genre and facebook link form
Corrected error in 'for' attribute for facebook label.