### PR TITLE
Removal of depreciated arg from readme guide

### DIFF
--- a/projects/01_fyyur/starter_code/README.md
+++ b/projects/01_fyyur/starter_code/README.md
@@ -124,7 +124,7 @@ To start and run the local development server,
 1. Initialize and activate a virtualenv:
   ```
   $ cd YOUR_PROJECT_DIRECTORY_PATH/
-  $ virtualenv --no-site-packages env
+  $ virtualenv env
   $ source env/bin/activate
   ```
 


### PR DESCRIPTION
Removed --no-site-packages from virtualenv setup. This arg was depreciated in v 16 and then removed from virtualenv in v20. --no-site-packages is now default behaviour. (See here: https://virtualenv.pypa.io/en/16.7.9/reference.html)