### PR TITLE
Update FlaskRecap requirements.txt

### DIFF
--- a/FlaskRecap/requirements.txt
+++ b/FlaskRecap/requirements.txt
@@ -3,4 +3,4 @@ Flask==1.0.3
 itsdangerous==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.1
-Werkzeug==0.15.4
+Werkzeug==1.0.1


### PR DESCRIPTION
The requirements.txt causes the FlaskRecap app to have an Internal Server Error (TypeError: required field "type_ignores" missing from Module). The issue is because of Werkzeug's version, it should be updated to 1.0.1.