### PR TITLE
Update default branch name references.

### DIFF
--- a/projects/01_fyyur/starter_code/README.md
+++ b/projects/01_fyyur/starter_code/README.md
@@ -145,13 +145,13 @@ cd FSND/projects/01_fyyur/starter_code
 git remote -v 
 git remote remove origin 
 git remote add origin <https://github.com/<USERNAME>/<REPO_NAME>.git>
-git branch -M master
+git branch -M main
 ```
 Once you have finished editing your code, you can push the local repository to your Github account using the following commands.
 ```
 git add . --all   
 git commit -m "your comment"
-git push -u origin master
+git push -u origin main
 ```
 
 3. **Initialize and activate a virtualenv using:**


### PR DESCRIPTION
In October 2020 Github updated its default branch naming convention to "main" and all new repositories use this convention. For more information see https://github.com/github/renaming.