### PR TITLE
(Frontend) Add missing 'props' to React class constructors and super() call

### DIFF
--- a/projects/02_trivia_api/starter/frontend/src/components/FormView.js
+++ b/projects/02_trivia_api/starter/frontend/src/components/FormView.js
@@ -5,7 +5,7 @@ import '../stylesheets/FormView.css';
 
 class FormView extends Component {
   constructor(props){
-    super();
+    super(props);
     this.state = {
       question: "",
       answer: "",

--- a/projects/02_trivia_api/starter/frontend/src/components/Question.js
+++ b/projects/02_trivia_api/starter/frontend/src/components/Question.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import '../stylesheets/Question.css';
 
 class Question extends Component {
-  constructor(){
-    super();
+  constructor(props){
+    super(props);
     this.state = {
       visibleAnswer: false
     }

--- a/projects/02_trivia_api/starter/frontend/src/components/QuestionView.js
+++ b/projects/02_trivia_api/starter/frontend/src/components/QuestionView.js
@@ -6,8 +6,8 @@ import Search from './Search';
 import $ from 'jquery';
 
 class QuestionView extends Component {
-  constructor(){
-    super();
+  constructor(props){
+    super(props);
     this.state = {
       questions: [],
       page: 1,

--- a/projects/02_trivia_api/starter/frontend/src/components/QuizView.js
+++ b/projects/02_trivia_api/starter/frontend/src/components/QuizView.js
@@ -7,7 +7,7 @@ const questionsPerPlay = 5;
 
 class QuizView extends Component {
   constructor(props){
-    super();
+    super(props);
     this.state = {
         quizCategory: null,
         previousQuestions: [], 


### PR DESCRIPTION
The `props` parameter is missing on React classes. I got warnings on WebStorm about this

Note that this is not required for the app to work properly (it would be if you did `this.props`, which is not the case now).