### PR TITLE
Update requirements.txt

### DIFF
--- a/projects/capstone/heroku_sample/starter/requirements.txt
+++ b/projects/capstone/heroku_sample/starter/requirements.txt
@@ -3,7 +3,6 @@ click==8.0.1
 Flask==1.1.2
 Flask-Cors==3.0.10
 Flask-Migrate==2.7.0
-Flask-Script==2.0.6
 Flask-SQLAlchemy==2.5.1
 greenlet==1.1.0
 gunicorn==20.1.0


### PR DESCRIPTION
Flask-Script==2.0.6 has been deprecated and was removed.   Its functionality is included in the latest versions of Flask-Migrate.