### PR TITLE
add environment.yml for conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+name: FSND
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9


### PR DESCRIPTION
01_fyyur project does not work due to python 3.10 change for collections. Error thrown for python-dateutil==2.6.0 due to collections.Callable vs collection.abs.Callable in python 3.10. 
Please provide a python version number to run your projects in working environment. 
Fix: I added a environment.yml to fix python version.